### PR TITLE
Fix not responding issue on Ubuntu

### DIFF
--- a/src/flow.py
+++ b/src/flow.py
@@ -12,10 +12,10 @@ class Flow:
         self.timer.timeout.connect(self.check_mouse_position)
         screen_count = desktop.screenCount()
         screen_geometries = [desktop.screen(i).geometry() for i in range(screen_count)]
-        self.rightmost_edge = max([geometry.x() + geometry.width() for geometry in screen_geometries])
+        self.rightmost_edge = max([geometry.x() + geometry.width() for geometry in screen_geometries])-1
         self.leftmost_edge = min([geometry.x() for geometry in screen_geometries])
         self.topmost_edge = min([geometry.y() for geometry in screen_geometries])
-        self.bottommost_edge = max([geometry.y() + geometry.height() for geometry in screen_geometries])
+        self.bottommost_edge = max([geometry.y() + geometry.height() for geometry in screen_geometries])-1
         self.offsets = {
             'left': QPoint(1, 0),
             'right': QPoint(-1, 0),


### PR DESCRIPTION
## Summary
- Subtracts 1 from `rightmost_edge` and `bottommost_edge` screen edge calculations in `src/flow.py`
- On Ubuntu, the mouse cursor position never reaches the exact screen dimension value, so the edge detection comparison (`>=`) would never trigger, causing the app to appear unresponsive
- This is the code fix from PR #4 without the unrelated `hidapitester` binary

## Test plan
- [ ] Run on Ubuntu and verify mouse flow triggers correctly when cursor reaches screen edges
- [ ] Verify Windows/macOS behavior is not affected

Fixes #3