### PR TITLE
feat(cli): add stateless CLI channel switcher with auto-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Supports both **Unifying** (HID++ 1.0) and **Bolt** (HID++ 2.0) protocols. See [
 
 Use `python tools/probe_devices.py` to discover your device's Receiver Slot and ID values.
 
+## Command-Line Tools
+
+For keyboard shortcut-based channel switching or device discovery, see the [tools/](tools/) directory:
+
+- **[CLI Switcher](tools/README.md#cli-switcher)** - Stateless channel switching with zero-touch auto-configuration
+- **[Probe Devices](tools/README.md#probe-devices)** - Discover receiver and device configuration values
+- **[Keyboard Shortcuts](tools/shortcuts/README.md)** - Ready-to-use scripts for Windows, Linux, and macOS
+
+Perfect for:
+- Users who prefer keyboard shortcuts over automatic edge-switching
+- Enterprise deployments with DLP/zero-trust policies (no clipboard-sharing)
+- Environments where background processes are restricted
+
 ## Mouse Emulation
 Prevents computer sleep when you're focused on another machine. Moves the mouse after 45 seconds of inactivity and simulates F15 keypress every 30 seconds. Resets when user activity is detected.
 

--- a/src/flow.py
+++ b/src/flow.py
@@ -1,12 +1,15 @@
-import platform
-import subprocess
 import time
 from PyQt6.QtCore import Qt, QTimer, QPoint, QThread, pyqtSignal
 from PyQt6.QtGui import QCursor
 from PyQt6.QtWidgets import QApplication
 
 from settings import config
-from utils import get_absolute_file_data_path, creation_flags
+from hid_protocol import (
+    get_hidapi_executable,
+    build_channel_switch_packet,
+    build_hidapi_command,
+    send_hid_command
+)
 
 
 class ChannelSwitchThread(QThread):
@@ -20,73 +23,21 @@ class ChannelSwitchThread(QThread):
         self._position = position
 
     def run(self):
-        success_ms = _write_to_adu(self._ms_cmd)
-        success_kb = _write_to_adu(self._kb_cmd)
+        success_ms = _send_hid_packet(self._ms_cmd)
+        success_kb = _send_hid_packet(self._kb_cmd)
         self.finished.emit(success_ms, success_kb, self._position)
 
 
-def _get_hidapi_executable_full_path():
-    arch = platform.machine()
-    system = platform.system().lower()
-    executable = None
-
-    if system == 'windows':
-        if arch in ('x86_64', 'AMD64'):
-            executable = 'hidapitester-windows-x86_64.exe'
-    elif system == 'linux':
-        if arch == 'x86_64':
-            executable = 'hidapitester-linux-x86_64'
-        elif arch == 'armv7l':
-            executable = 'hidapitester-linux-armv7l'
-    elif system == 'darwin':
-        if arch == 'arm64':
-            executable = 'hidapitester-macos-arm64'
-        elif arch == 'x86_64':
-            executable = 'hidapitester-macos-x86_64'
-
-    if executable is None:
-        raise RuntimeError(f"Unsupported platform: {system} {arch}")
-
-    return get_absolute_file_data_path('hidapitester', executable)
-
-
-def _build_hidapi_command(msg_str):
-    exec_path = _get_hidapi_executable_full_path()
-    hex_string = ','.join(f'0x{byte:02X}' for byte in msg_str)
-    length = str(len(msg_str))
-    usage = '2' if config.PROTOCOL == 'bolt' else '1'
-    cmd = [
-        exec_path, '--vidpid', f'{config.VENDOR_ID:04X}:{config.PRODUCT_ID:04X}',
-        '--usage', usage, '--usagePage', '0xFF00', '--open',
-        '--length', length, '--send-output', hex_string,
-        '--length', length, '--send-output', hex_string,
-    ]
-    return cmd
-
-
-def _write_to_adu(msg_str):
-    cmd = _build_hidapi_command(msg_str)
+def _send_hid_packet(msg_bytes):
+    """Send HID packet with retries using consolidated protocol functions."""
+    cmd = build_hidapi_command(
+        config.VENDOR_ID,
+        config.PRODUCT_ID,
+        config.PROTOCOL,
+        msg_bytes
+    )
     print('Writing command: {}'.format(' '.join(cmd)))
-    max_retries = 10
-    success_msg = f"wrote {len(msg_str)} bytes"
-
-    for attempt in range(1, max_retries + 1):
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, creationflags=creation_flags)
-        except Exception as e:
-            print('Error writing command: {}'.format(e))
-            if attempt < max_retries:
-                time.sleep(0.1)
-            continue
-
-        if success_msg in result.stdout:
-            return True
-        else:
-            print(f'Attempt {attempt}: Failed to write command')
-            if attempt < max_retries:
-                time.sleep(0.1)
-
-    return False
+    return send_hid_command(cmd, success_indicator='wrote', max_retries=10)
 
 
 class Flow:
@@ -174,3 +125,17 @@ class Flow:
             self._switch_thread.finished.connect(self._on_switch_finished)
             self._switch_thread.start()
             break
+# Build channel switch packets using protocol functions
+            ms_cmd = build_channel_switch_packet(
+                config.PROTOCOL,
+                config.MS_RECEIVER_SLOT,
+                config.MOUSE_ID,
+                channel
+            )
+            kb_cmd = build_channel_switch_packet(
+                config.PROTOCOL,
+                config.KB_RECEIVER_SLOT,
+                config.KEYBOARD_ID,
+                channel
+            )
+            

--- a/src/hid_protocol.py
+++ b/src/hid_protocol.py
@@ -1,0 +1,331 @@
+"""HID++ protocol definitions and utilities for Logitech devices.
+
+Consolidates HID communication logic previously duplicated across
+flow.py, cli_switcher.py, and probe_devices.py.
+"""
+
+import subprocess
+import time
+import platform
+from utils import get_absolute_file_data_path, creation_flags
+
+# Protocol constants
+BOLT_REPORT_ID = 0x11
+UNIFYING_REPORT_ID = 0x10
+BOLT_CHANGE_HOST_FUNC = 0x1E
+UNIFYING_CHANGE_HOST_FUNC = 0x1C
+BOLT_PACKET_LENGTH = 20
+UNIFYING_PACKET_LENGTH = 7
+
+# Feature IDs
+FEATURE_CHANGE_HOST = 0x1814
+FEATURE_IROOT = 0x00
+
+# HID++ functions
+FUNC_GET_FEATURE = 0x0F
+FUNC_PING = 0x1F
+
+# Default VID:PIDs
+DEFAULT_BOLT_VIDPID = ('046D', 'C548')
+DEFAULT_UNIFYING_VIDPID = ('046D', 'C52B')
+
+
+def get_hidapi_executable():
+    """Get platform-specific hidapitester binary path.
+    
+    Consolidates implementations from flow.py, cli_switcher.py, and probe_devices.py.
+    """
+    system = platform.system().lower()
+    arch = platform.machine()
+    
+    if system == 'windows':
+        return get_absolute_file_data_path('hidapitester', 'hidapitester-windows-x86_64.exe')
+    elif system == 'darwin':
+        name = 'hidapitester-macos-arm64' if arch == 'arm64' else 'hidapitester-macos-x86_64'
+        return get_absolute_file_data_path('hidapitester', name)
+    else:  # linux
+        name = 'hidapitester-linux-armv7l' if arch == 'armv7l' else 'hidapitester-linux-x86_64'
+        return get_absolute_file_data_path('hidapitester', name)
+
+
+def format_vidpid(vendor_id, product_id):
+    """Format VID:PID as hex string (e.g., '046D:C548')."""
+    return f'{int(vendor_id, 16) if isinstance(vendor_id, str) else vendor_id:04X}:{int(product_id, 16) if isinstance(product_id, str) else product_id:04X}'
+
+
+def build_channel_switch_packet(protocol, receiver_slot, feature_index, channel):
+    """Build HID++ packet for channel switching.
+    
+    Args:
+        protocol: 'bolt' or 'unifying'
+        receiver_slot: Device slot on receiver (1-6)
+        feature_index: Change Host feature index
+        channel: Target channel (1-3)
+        
+    Returns:
+        List of bytes representing the HID++ packet
+    """
+    channel_byte = channel - 1  # Channels are 0-indexed in protocol
+    
+    if protocol == 'bolt':
+        # Bolt: 20-byte packet
+        packet = [BOLT_REPORT_ID, receiver_slot, feature_index, BOLT_CHANGE_HOST_FUNC, channel_byte] + [0x00] * 15
+    else:  # unifying
+        # Unifying: 7-byte packet
+        packet = [UNIFYING_REPORT_ID, receiver_slot, feature_index, UNIFYING_CHANGE_HOST_FUNC, channel_byte, 0x00, 0x00]
+    
+    return packet
+
+
+def build_hidapi_command(vendor_id, product_id, protocol, msg_bytes, exec_path=None):
+    """Build hidapitester command array.
+    
+    Consolidates command building from flow.py and cli_switcher.py.
+    
+    Args:
+        vendor_id: Vendor ID (string like '046D' or int)
+        product_id: Product ID (string like 'C548' or int)
+        protocol: 'bolt' or 'unifying'
+        msg_bytes: Message bytes to send
+        exec_path: Path to hidapitester (optional, auto-detected if None)
+        
+    Returns:
+        List of command arguments for subprocess
+    """
+    if exec_path is None:
+        exec_path = get_hidapi_executable()
+    
+    vidpid = format_vidpid(vendor_id, product_id)
+    hex_string = ','.join(f'0x{byte:02X}' for byte in msg_bytes)
+    length = str(len(msg_bytes))
+    usage = '2' if protocol == 'bolt' else '1'
+    
+    return [
+        exec_path, '--vidpid', vidpid,
+        '--usage', usage, '--usagePage', '0xFF00', '--open',
+        '--length', length, '--send-output', hex_string,
+        '--length', length, '--send-output', hex_string,  # Send twice for device wake
+    ]
+
+
+def send_hid_command(cmd, success_indicator='wrote', max_retries=3, timeout=5, quiet=False):
+    """Send HID command with retries.
+    
+    Consolidates execution logic from flow.py and cli_switcher.py.
+    
+    Args:
+        cmd: Command array for subprocess
+        success_indicator: String to look for in output to indicate success
+        max_retries: Maximum retry attempts
+        timeout: Timeout in seconds per attempt
+        quiet: Suppress error output
+        
+    Returns:
+        True on success, False on failure
+    """
+    for attempt in range(max_retries):
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                creationflags=creation_flags
+            )
+            
+            output = result.stdout + result.stderr
+            
+            # Check for success indicator
+            if success_indicator in output.lower():
+                return True
+                
+        except subprocess.TimeoutExpired:
+            if not quiet:
+                print(f'  Attempt {attempt + 1}/{max_retries} timed out')
+        except Exception as e:
+            if not quiet:
+                print(f'  Attempt {attempt + 1}/{max_retries} failed: {e}')
+        
+        if attempt < max_retries - 1:
+            time.sleep(0.5)  # Brief delay between retries
+    
+    return False
+
+
+def send_hid_receive(exec_path, vidpid, protocol, msg_bytes, force_short=False, timeout=2):
+    """Send HID command and parse response.
+    
+    From probe_devices.py with enhancements.
+    
+    Args:
+        exec_path: Path to hidapitester executable
+        vidpid: VID:PID string (e.g., '046D:C548')
+        protocol: 'bolt' or 'unifying'
+        msg_bytes: Message bytes to send (list of ints)
+        force_short: Force short endpoint (7 bytes, usage 1) even for Bolt
+        timeout: Timeout in milliseconds
+        
+    Returns:
+        Tuple of (success, raw_output, response_bytes)
+    """
+    # Determine packet length and usage
+    if force_short or protocol != 'bolt':
+        if len(msg_bytes) < UNIFYING_PACKET_LENGTH:
+            msg_bytes = msg_bytes + [0x00] * (UNIFYING_PACKET_LENGTH - len(msg_bytes))
+        length = str(UNIFYING_PACKET_LENGTH)
+        usage = '1'
+    else:
+        if len(msg_bytes) < BOLT_PACKET_LENGTH:
+            msg_bytes = msg_bytes + [0x00] * (BOLT_PACKET_LENGTH - len(msg_bytes))
+        length = str(BOLT_PACKET_LENGTH)
+        usage = '2'
+    
+    hex_string = ','.join(f'0x{b:02X}' for b in msg_bytes)
+    cmd = [
+        exec_path, '--vidpid', vidpid,
+        '--usage', usage, '--usagePage', '0xFF00', '--open',
+        '--length', length, '--send-output', hex_string,
+        '--length', length, '--send-output', hex_string,  # Send twice
+        '--timeout', str(timeout),
+        '--length', length, '--read-input',
+    ]
+    
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout / 1000 + 1,  # Convert ms to seconds + buffer
+            creationflags=creation_flags
+        )
+        output = result.stdout + result.stderr
+        
+        # Parse response bytes from output
+        response = parse_response_bytes(output)
+        if response:
+            return True, output, response
+        
+        # Fallback: check if hidapitester read any bytes
+        if 'read 7 bytes' in output or 'read 20 bytes' in output:
+            return True, output, None
+        
+        return False, output, None
+        
+    except subprocess.TimeoutExpired:
+        return False, 'timeout', None
+    except Exception as e:
+        return False, str(e), None
+
+
+def parse_response_bytes(output):
+    """Extract response bytes from hidapitester read output.
+    
+    From probe_devices.py.
+    
+    hidapitester format:
+        Reading N-byte input report ...read N bytes:
+         AA BB CC DD ...
+    Hex bytes are on the NEXT line after 'read N bytes:'.
+    
+    Args:
+        output: stdout/stderr text from hidapitester
+        
+    Returns:
+        List of response bytes (ints), or None if not found
+    """
+    lines = output.split('\n')
+    for i, line in enumerate(lines):
+        if 'read' in line and 'bytes' in line and 'read 0 bytes' not in line:
+            # Check same line after colon
+            parts = line.split(':')
+            if len(parts) > 1:
+                hex_part = parts[-1].strip()
+                if hex_part:
+                    try:
+                        return [int(b, 16) for b in hex_part.split()]
+                    except ValueError:
+                        pass
+            
+            # Check next line for hex bytes
+            if i + 1 < len(lines):
+                next_line = lines[i + 1].strip()
+                if next_line:
+                    try:
+                        return [int(b, 16) for b in next_line.split()]
+                    except ValueError:
+                        pass
+    
+    return None
+
+
+def ping_device(exec_path, vidpid, protocol, device_index):
+    """HID++ 2.0 ping to check if device exists.
+    
+    From probe_devices.py.
+    
+    Sends IRoot (feature 0x00) ping (function 0x1F) with swID=0x0F.
+    Tries short endpoint first. For Bolt, also tries long endpoint if short fails.
+    
+    Args:
+        exec_path: Path to hidapitester
+        vidpid: VID:PID string
+        protocol: 'bolt' or 'unifying'
+        device_index: Device slot to ping (0-8)
+        
+    Returns:
+        Tuple of (success, raw_output, response_bytes)
+    """
+    # Try short ping first
+    msg_short = [UNIFYING_REPORT_ID, device_index, FEATURE_IROOT, FUNC_PING, 0x00, 0x00, 0xAA]
+    ok, output, response = send_hid_receive(exec_path, vidpid, protocol, msg_short, force_short=True)
+    
+    if ok:
+        # Check if it's an error response (0x8F = HID++ error)
+        if response and len(response) >= 3 and response[2] == 0x8F:
+            return False, output, response
+        return True, output, response
+    
+    # For Bolt, try long endpoint if short didn't work
+    if protocol == 'bolt':
+        msg_long = [BOLT_REPORT_ID, device_index, FEATURE_IROOT, FUNC_PING] + [0x00] * 15 + [0xAA]
+        ok, output, response = send_hid_receive(exec_path, vidpid, protocol, msg_long)
+        
+        if ok:
+            if response and len(response) >= 3 and response[2] == 0x8F:
+                return False, output, response
+            return True, output, response
+    
+    return False, output, response
+
+
+def query_feature_index(exec_path, vidpid, protocol, device_index, feature_id):
+    """Query IRoot.getFeature to find a feature's index.
+    
+    From probe_devices.py.
+    
+    IRoot is always at feature index 0x00, function 0 = getFeature.
+    
+    Args:
+        exec_path: Path to hidapitester
+        vidpid: VID:PID string
+        protocol: 'bolt' or 'unifying'
+        device_index: Device slot
+        feature_id: Feature ID to query (e.g., 0x1814 for Change Host)
+        
+    Returns:
+        Tuple of (feature_index, raw_output). feature_index is None if not found.
+    """
+    feat_hi = (feature_id >> 8) & 0xFF
+    feat_lo = feature_id & 0xFF
+    
+    if protocol == 'bolt':
+        msg = [BOLT_REPORT_ID, device_index, FEATURE_IROOT, FUNC_GET_FEATURE, feat_hi, feat_lo]
+    else:
+        msg = [UNIFYING_REPORT_ID, device_index, FEATURE_IROOT, FUNC_GET_FEATURE, feat_hi, feat_lo]
+    
+    ok, output, response = send_hid_receive(exec_path, vidpid, protocol, msg)
+    
+    if ok and response and len(response) > 4:
+        return response[4], output  # Feature index is in byte 4
+    
+    return None, output

--- a/src/uniclip.py
+++ b/src/uniclip.py
@@ -1,7 +1,6 @@
-import platform
 import re
 import subprocess
-from utils import get_absolute_file_data_path, creation_flags
+from utils import get_platform_executable, creation_flags
 from settings import config
 
 class Uniclip:
@@ -11,35 +10,8 @@ class Uniclip:
         self.client_process = None
 
     def get_uniclip_executable_full_path(self):
-        arch = platform.machine()
-        system = platform.system().lower()
-        executable = None
-        if system == 'windows':
-            if arch in ('x86_64', 'AMD64'):
-                executable = 'uniclip-windows-x86_64.exe'
-            elif arch == 'armv6l':
-                executable = 'uniclip-windows-armv6.exe'
-            elif arch == 'x86':
-                executable = 'uniclip-windows-x86.exe'
-        elif system == 'linux':
-            if arch == 'x86_64':
-                executable = 'uniclip-linux-x86_64'
-            elif arch == 'armv6l':
-                executable = 'uniclip-linux-armv6'
-            elif arch in ('arm64', 'aarch64'):
-                executable = 'uniclip-linux-arm64'
-            elif arch == 'x86':
-                executable = 'uniclip-linux-x86'
-        elif system == 'darwin':
-            if arch == 'x86_64':
-                executable = 'uniclip-macos-x86_64'
-            elif arch == 'arm64':
-                executable = 'uniclip-macos-arm64'
-
-        if executable is None:
-            raise RuntimeError(f"Unsupported platform: {system} {arch}")
-
-        return get_absolute_file_data_path('uniclip', executable)
+        """Get platform-specific uniclip binary path."""
+        return get_platform_executable('uniclip', 'uniclip')
 
     def start_server(self):
         if self.server_process:

--- a/src/utils.py
+++ b/src/utils.py
@@ -14,7 +14,70 @@ def get_absolute_folder_data_path(folder_name):
 def get_absolute_file_data_path(folder_name, file_name):
     return os.path.join(get_absolute_folder_data_path(folder_name), file_name)
 
+# Platform detection
 system = platform.system().lower()
+machine = platform.machine()
+
+def is_windows():
+    """Check if running on Windows."""
+    return system == 'windows'
+
+def is_mac():
+    """Check if running on macOS."""
+    return system == 'darwin'
+
+def is_linux():
+    """Check if running on Linux."""
+    return system == 'linux'
+
+# Windows subprocess flag to suppress console windows
 creation_flags = 0
-if system == 'windows':  # Check if the current OS is Windows
+if is_windows():
     creation_flags = subprocess.CREATE_NO_WINDOW
+
+
+def get_platform_executable(binary_base, folder, extensions=None):
+    """Get platform-specific executable path with automatic architecture detection.
+    
+    Generic helper for resolving platform-specific binaries like hidapitester, uniclip, etc.
+    
+    Args:
+        binary_base: Base name of binary (e.g., 'hidapitester', 'uniclip')
+        folder: Folder name in static/ directory
+        extensions: Dict mapping platform to extension (default: .exe for Windows, none for others)
+        
+    Returns:
+        Full path to platform-specific executable
+        
+    Example:
+        get_platform_executable('uniclip', 'uniclip')
+        # Returns: .../static/uniclip/uniclip-windows-x86_64.exe (on Windows x64)
+    """
+    if extensions is None:
+        extensions = {'windows': '.exe', 'darwin': '', 'linux': ''}
+    
+    ext = extensions.get(system, '')
+    
+    # Platform-specific naming
+    if system == 'windows':
+        # Windows: typically x86_64 only
+        filename = f'{binary_base}-windows-x86_64{ext}'
+    elif system == 'darwin':
+        # macOS: arm64 or x86_64
+        arch = 'arm64' if machine == 'arm64' else 'x86_64'
+        filename = f'{binary_base}-macos-{arch}{ext}'
+    else:  # linux
+        # Linux: x86_64, armv7l, armv6, arm64, x86
+        if machine == 'armv7l':
+            arch = 'armv7l'
+        elif machine == 'armv6l':
+            arch = 'armv6'
+        elif machine == 'aarch64':
+            arch = 'arm64'
+        elif machine in ('i386', 'i686'):
+            arch = 'x86'
+        else:
+            arch = 'x86_64'
+        filename = f'{binary_base}-linux-{arch}{ext}'
+    
+    return get_absolute_file_data_path(folder, filename)

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,288 @@
+# Logitech Channel Switcher - Tools
+
+Command-line utilities for device discovery and channel switching.
+
+## Contents
+
+- [CLI Switcher](#cli-switcher) - Stateless channel switching with keyboard shortcut support
+- [Probe Devices](#probe-devices) - Discover paired devices and their configuration values
+
+---
+
+## CLI Switcher
+
+Lightweight command-line tool for channel switching via keyboard shortcuts or scripts, without requiring the main GUI application.
+
+### Features
+
+- ✅ **Stateless execution** - No background processes required
+- ✅ **Silent operation** - No console windows (when using shortcuts)
+- ✅ **Global keyboard shortcuts** - Works system-wide
+- ✅ **Zero-touch auto-configuration** - First-run automatic device detection
+- ✅ **Interactive configuration** - Manual device identification if needed
+- ✅ **Cross-platform** - Windows, Linux, macOS
+
+### Quick Start
+
+```bash
+# First-run: Auto-configure (silent)
+python tools/cli_switcher.py --channel 1 --quiet
+# Detects receiver, assigns first device=keyboard, second=mouse
+
+# Or: Interactive configuration (prompts for device selection)
+python tools/cli_switcher.py --channel 1
+
+# Switch to channel 2 silently
+python tools/cli_switcher.py --channel 2 --quiet
+```
+
+### Usage
+
+```bash
+python tools/cli_switcher.py --channel <1|2|3> [--quiet]
+
+Arguments:
+  --channel <1|2|3>   Target channel to switch to (required)
+  --quiet             Silent mode, no output (auto-configures on first run)
+```
+
+### Auto-Configuration (Quiet Mode)
+
+On first run, the CLI automatically detects your Logitech receiver and paired devices:
+
+- Tries **Bolt** protocol first (`046D:C548`), falls back to **Unifying** (`046D:C52B`)
+- First device found is assigned as **keyboard**
+- Second device found is assigned as **mouse**
+- Configuration saved to `~/.lcs_config/config.json`
+- No user interaction required (perfect for enterprise deployment)
+
+**Why it works:** The first paired device is typically the keyboard, and the second is the mouse. Even if they're swapped, both devices receive the same channel-switch command, so functionality is identical.
+
+### Interactive Configuration
+
+If you prefer to manually identify your devices:
+
+```bash
+python tools/cli_switcher.py --channel 1
+```
+
+The interactive mode will:
+1. Detect available receivers (Bolt/Unifying)
+2. Discover paired devices
+3. Let you test each device by sending a switch command
+4. Observe which physical device responds (LED blinks or channel switches)
+5. Save your selections to config
+
+### Configuration File
+
+Settings are stored in `~/.lcs_config/config.json`:
+
+```json
+{
+  "PROTOCOL": "bolt",
+  "VENDOR_ID": "046D",
+  "PRODUCT_ID": "C548",
+  "KB_RECEIVER_SLOT": 1,
+  "MS_RECEIVER_SLOT": 2,
+  "KEYBOARD_ID": 10,
+  "MOUSE_ID": 10
+}
+```
+
+**Field Descriptions:**
+- `PROTOCOL`: `"bolt"` (HID++ 2.0) or `"unifying"` (HID++ 1.0)
+- `VENDOR_ID`/`PRODUCT_ID`: USB identifiers (hex without `0x` prefix)
+- `KB_RECEIVER_SLOT`/`MS_RECEIVER_SLOT`: Device slot on receiver (1-6, typically 1 and 2)
+- `KEYBOARD_ID`/`MOUSE_ID`: Change Host feature index (use [probe_devices.py](#probe-devices) to discover)
+
+**Note:** Both devices can have the same feature index - the `RECEIVER_SLOT` differentiates them, not the feature index. See [DEVICE_CONFIG_EXPLAINED.md](DEVICE_CONFIG_EXPLAINED.md) for details.
+
+### Keyboard Shortcuts
+
+Pre-configured shortcut scripts are available in `tools/shortcuts/`:
+
+- **Windows:** `.bat` files using `pythonw.exe` (no console flash)
+- **Linux/macOS:** `.sh` shell scripts
+
+**Setup:**
+1. Run `configure.bat` (Windows) or `configure.sh` (Linux/macOS) to set up your devices
+2. Create keyboard shortcuts pointing to the channel switcher scripts:
+   - `switch-channel-1.bat` / `switch-channel-1.sh`
+   - `switch-channel-2.bat` / `switch-channel-2.sh`
+   - `switch-channel-3.bat` / `switch-channel-3.sh`
+
+See [shortcuts/README.md](shortcuts/README.md) for detailed platform-specific setup instructions.
+
+### Exit Codes
+
+- `0` - Success
+- `1` - Configuration error (missing config, invalid values)
+- `2` - HID communication failure (device not found, command failed)
+- `3` - Invalid arguments
+
+### Enterprise Deployment
+
+For IT teams deploying to multiple machines:
+
+**Zero-Touch Setup:**
+```powershell
+# Deploy script + create shortcut with --quiet flag
+python tools/cli_switcher.py --channel 1 --quiet
+```
+
+The `--quiet` flag enables fully automated configuration on first run. No user prompts, ideal for:
+- Group Policy Object (GPO) deployments
+- Configuration management tools (Ansible, Puppet, etc.)
+- DLP-compliant environments
+- Zero-trust security policies
+
+**Pre-Configuration:**
+
+Alternatively, deploy a pre-configured `config.json` to `%USERPROFILE%\.lcs_config\` (Windows) or `~/.lcs_config/` (Unix) to skip auto-detection entirely.
+
+### Troubleshooting
+
+**"No receiver found"**
+- Verify receiver is plugged in
+- Check devices are on and paired
+- Try running `probe_devices.py` to confirm detection
+- On Linux, may need `sudo` for HID access
+
+**"Channel switch command failed"**
+- Ensure devices are awake (move mouse, press key)
+- Verify `RECEIVER_SLOT` values are different (1 vs 2, not both 1)
+- Check feature indices with `probe_devices.py`
+
+**Configuration issues**
+- Delete `~/.lcs_config/config.json` and run again
+- Use `configure.bat`/`configure.sh` for interactive setup
+- See [DEVICE_CONFIG_EXPLAINED.md](DEVICE_CONFIG_EXPLAINED.md) for slot vs feature index explanation
+
+---
+
+## Probe Devices
+
+Utility to discover Logitech Bolt/Unifying receivers and query paired devices for their configuration values.
+
+### Purpose
+
+Finds the `RECEIVER_SLOT` and `DEVICE_ID` (Change Host feature index) values needed for `config.json`.
+
+### Usage
+
+```bash
+python tools/probe_devices.py [--protocol bolt|unifying] [VID:PID] [--debug]
+
+Arguments:
+  --protocol   bolt or unifying (default: bolt)
+  VID:PID      Vendor:Product ID in hex (default: 046D:C548 for Bolt)
+  --debug      Show detailed HID communication logs
+
+Examples:
+  python tools/probe_devices.py
+  python tools/probe_devices.py --protocol unifying 046D:C52B
+  python tools/probe_devices.py --debug
+```
+
+### What It Does
+
+**Step 1: Device Discovery**
+- Pings device indices 0-8 using HID++ 2.0 ping command (IRoot feature)
+- Reports which slots have paired devices
+
+**Step 2: Feature Query**
+- Queries each discovered device for the **Change Host (0x1814)** feature
+- Returns the feature index for each device
+
+### Example Output
+
+```
+Probe v0.5 — Probing receiver 046D:C548 (protocol: bolt)
+Using: C:\...\hidapitester-windows-x86_64.exe
+
+--- Step 1: Pinging device indices 0-8 ---
+
+  Device index 0: -       
+  Device index 1: FOUND   
+  Device index 2: FOUND   
+  Device index 3: -       
+  ...
+
+--- Step 2: Querying Change Host (0x1814) feature index ---
+
+  Device index 1: Change Host feature at index 10 (0x0A)
+  Device index 2: Change Host feature at index 10 (0x0A)
+
+--- Summary ---
+
+  Protocol:   bolt
+  VID:PID:    046D:C548
+
+  Device index (RECEIVER_SLOT): 1
+  Change Host feature index (DEVICE_ID): 10 (0x0A)
+
+  Device index (RECEIVER_SLOT): 2
+  Change Host feature index (DEVICE_ID): 10 (0x0A)
+
+Use these values in config.json:
+  KB_RECEIVER_SLOT: 1, KEYBOARD_ID: 10
+  MS_RECEIVER_SLOT: 2, MOUSE_ID: 10
+```
+
+### Understanding the Output
+
+- **RECEIVER_SLOT** - The slot number where your device is paired (1-6)
+- **DEVICE_ID** - Change Host feature index (varies by device model)
+- Both devices can have the **same feature index** - this is normal!
+  - The RECEIVER_SLOT differentiates them
+  - Both receive identical channel-switch commands
+
+### Protocol Detection
+
+**Default Bolt VID:PID:** `046D:C548`
+- Bolt receivers (newer, uses HID++ 2.0)
+- 20-byte packets, report ID `0x11`
+
+**Unifying VID:PID:** `046D:C52B`
+- Unifying receivers (older, uses HID++ 1.0)
+- 7-byte packets, report ID `0x10`
+
+If your receiver isn't detected, check Windows Device Manager or `lsusb` on Linux to find the correct VID:PID.
+
+### Wake-Up Behavior
+
+The tool sends commands **twice with a 2-second timeout** to wake sleeping devices. However, it's unverified whether this alone is sufficient - user activity during testing (moving mouse, pressing keys) may be required to wake devices.
+
+If devices aren't detected, try:
+1. Moving your mouse or pressing a key
+2. Running the probe again immediately after
+3. Ensuring devices are on and within range
+
+### Technical Details
+
+Uses `hidapitester` binary (located in `static/hidapitester/`) to communicate with HID devices across platforms:
+
+- **Windows:** `hidapitester-windows-x86_64.exe`
+- **macOS:** `hidapitester-macos-arm64` / `hidapitester-macos-x86_64`
+- **Linux:** `hidapitester-linux-x86_64` / `hidapitester-linux-armv7l`
+
+**HID++ Commands:**
+- Ping: `[report_id, device_index, 0x00, 0x1F, 0x00, 0x00, 0xAA, ...]`
+- Get Feature: `[report_id, device_index, 0x00, 0x0F, feat_hi, feat_lo, ...]`
+
+See [Logitech HID++ specification](https://lekensteyn.nl/logitech-unifying.html) for protocol details.
+
+### Permissions
+
+- **Linux:** Requires `sudo` for HID access
+- **macOS:** May need Input Monitoring permission
+- **Windows:** No special permissions required
+
+---
+
+## See Also
+
+- [shortcuts/README.md](shortcuts/README.md) - Keyboard shortcut setup guide
+- [DEVICE_CONFIG_EXPLAINED.md](DEVICE_CONFIG_EXPLAINED.md) - Technical explanation of slots vs feature indices
+- [../BOLT_SETUP.md](../BOLT_SETUP.md) - Bolt protocol configuration guide
+- [../README.md](../README.md) - Main project documentation

--- a/tools/cli_switcher.py
+++ b/tools/cli_switcher.py
@@ -31,7 +31,19 @@ from pathlib import Path
 # Add src directory to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-from utils import get_absolute_file_data_path, creation_flags
+from utils import creation_flags
+from hid_protocol import (
+    get_hidapi_executable,
+    build_channel_switch_packet as build_packet,
+    build_hidapi_command as build_cmd,
+    send_hid_command as send_cmd,
+    format_vidpid,
+    ping_device,
+    query_feature_index,
+    FEATURE_CHANGE_HOST,
+    DEFAULT_BOLT_VIDPID,
+    DEFAULT_UNIFYING_VIDPID
+)
 
 # Minimal imports from settings (avoid PyQt6 dependencies)
 try:
@@ -102,107 +114,9 @@ def log_error(message):
     print(f"ERROR: {message}", file=sys.stderr)
 
 
-def get_hidapi_executable():
-    """Get platform-specific hidapitester binary path."""
-    import platform
-    system = platform.system().lower()
-    arch = platform.machine()
-    
-    if system == 'windows':
-        return get_absolute_file_data_path('hidapitester', 'hidapitester-windows-x86_64.exe')
-    elif system == 'darwin':
-        name = 'hidapitester-macos-arm64' if arch == 'arm64' else 'hidapitester-macos-x86_64'
-        return get_absolute_file_data_path('hidapitester', name)
-    else:
-        name = 'hidapitester-linux-armv7l' if arch == 'armv7l' else 'hidapitester-linux-x86_64'
-        return get_absolute_file_data_path('hidapitester', name)
-
-
-def build_hidapi_command(config, msg_bytes):
-    """Build hidapitester command for sending HID++ packet.
-    
-    Args:
-        config: Config object with VENDOR_ID, PRODUCT_ID, PROTOCOL
-        msg_bytes: list of bytes to send
-    
-    Returns:
-        List of command arguments for subprocess
-    """
-    exec_path = get_hidapi_executable()
-    hex_string = ','.join(f'0x{byte:02X}' for byte in msg_bytes)
-    length = str(len(msg_bytes))
-    usage = '2' if config.PROTOCOL == 'bolt' else '1'
-    
-    cmd = [
-        exec_path,
-        '--vidpid', f'{config.VENDOR_ID:04X}:{config.PRODUCT_ID:04X}',
-        '--usage', usage,
-        '--usagePage', '0xFF00',
-        '--open',
-        '--length', length,
-        '--send-output', hex_string,
-        '--length', length,
-        '--send-output', hex_string,  # Send twice for device wake
-    ]
-    return cmd
-
-
-def send_hid_command(config, msg_bytes, max_retries=3, quiet=False):
-    """Send HID command with retries.
-    
-    Args:
-        config: Config object
-        msg_bytes: list of bytes to send
-        max_retries: maximum number of retry attempts
-        quiet: suppress output if True
-    
-    Returns:
-        True if successful, False otherwise
-    """
-    cmd = build_hidapi_command(config, msg_bytes)
-    success_msg = f"wrote {len(msg_bytes)} bytes"
-    
-    for attempt in range(1, max_retries + 1):
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=5,
-                creationflags=creation_flags
-            )
-            
-            if success_msg in result.stdout:
-                return True
-            
-            # Retry with delay if not last attempt
-            if attempt < max_retries:
-                time.sleep(0.1)
-                
-        except subprocess.TimeoutExpired:
-            log(f"  Timeout on attempt {attempt}/{max_retries}", quiet)
-            if attempt < max_retries:
-                time.sleep(0.1)
-        except Exception as e:
-            log(f"  Error on attempt {attempt}/{max_retries}: {e}", quiet)
-            if attempt < max_retries:
-                time.sleep(0.1)
-    
-    return False
-
-
+# Wrapper functions to adapt hid_protocol functions to cli_switcher interface
 def build_channel_switch_packet(config, device_type, channel):
-    """Build HID++ packet for switching channels.
-    
-    Args:
-        config: Config object with protocol and device settings
-        device_type: 'keyboard' or 'mouse'
-        channel: target channel (1, 2, or 3)
-    
-    Returns:
-        List of bytes representing the HID++ packet
-    """
-    # Get device-specific slot and feature index
+    """Build channel switch packet - wrapper for hid_protocol function."""
     if device_type == 'keyboard':
         receiver_slot = config.KB_RECEIVER_SLOT
         feature_index = config.KEYBOARD_ID
@@ -210,18 +124,13 @@ def build_channel_switch_packet(config, device_type, channel):
         receiver_slot = config.MS_RECEIVER_SLOT
         feature_index = config.MOUSE_ID
     
-    # Convert channel to zero-indexed (1→0, 2→1, 3→2)
-    channel_byte = channel - 1
-    
-    # Build packet based on protocol
-    if config.PROTOCOL == 'bolt':
-        # Bolt: 20 bytes, report ID 0x11, function 0x1E
-        packet = [0x11, receiver_slot, feature_index, 0x1E, channel_byte] + [0x00] * 15
-    else:
-        # Unifying: 7 bytes, report ID 0x10, function 0x1C
-        packet = [0x10, receiver_slot, feature_index, 0x1C, channel_byte, 0x00, 0x00]
-    
-    return packet
+    return build_packet(config.PROTOCOL, receiver_slot, feature_index, channel)
+
+
+def send_hid_command(config, msg_bytes, max_retries=3, quiet=False):
+    """Send HID command - wrapper for hid_protocol function."""
+    cmd = build_cmd(config.VENDOR_ID, config.PRODUCT_ID, config.PROTOCOL, msg_bytes)
+    return send_cmd(cmd, success_indicator='wrote', max_retries=max_retries, timeout=5, quiet=quiet)
 
 
 def switch_channel(config, channel, quiet=False):

--- a/tools/cli_switcher.py
+++ b/tools/cli_switcher.py
@@ -1,0 +1,773 @@
+#!/usr/bin/env python3
+"""
+Logitech Channel Switcher CLI
+
+Stateless command-line tool for switching Logitech Bolt/Unifying keyboard
+and mouse channels without requiring background processes.
+
+Usage:
+    python cli_switcher.py --channel 1|2|3 [--quiet]
+
+Exit codes:
+    0 = Success
+    1 = Configuration error (missing/invalid config)
+    2 = HID communication failure
+    3 = Invalid arguments
+
+First-run behavior:
+    Interactive mode: Launches interactive device discovery
+    Quiet mode: Auto-configures using first two devices found
+                (first device = keyboard, second = mouse)
+                Tries Bolt protocol first, falls back to Unifying
+"""
+
+import argparse
+import subprocess
+import sys
+import os
+import time
+from pathlib import Path
+
+# Add src directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from utils import get_absolute_file_data_path, creation_flags
+
+# Minimal imports from settings (avoid PyQt6 dependencies)
+try:
+    from settings import Config, SettingsManager
+except ImportError:
+    # Fallback if PyQt6 not installed - define minimal config classes
+    import json
+    import platform
+    
+    class Config:
+        def __init__(self, PROTOCOL="unifying", VENDOR_ID=0x046D, PRODUCT_ID=0xC52B,
+                     KB_RECEIVER_SLOT=0x01, MS_RECEIVER_SLOT=0x02,
+                     KEYBOARD_ID=0x09, MOUSE_ID=0x0a, **kwargs):
+            self.PROTOCOL = PROTOCOL
+            self.VENDOR_ID = VENDOR_ID
+            self.PRODUCT_ID = PRODUCT_ID
+            self.KB_RECEIVER_SLOT = KB_RECEIVER_SLOT
+            self.MS_RECEIVER_SLOT = MS_RECEIVER_SLOT
+            self.KEYBOARD_ID = KEYBOARD_ID
+            self.MOUSE_ID = MOUSE_ID
+            # Store any extra kwargs for compatibility
+            self.__dict__.update(kwargs)
+        
+        def to_dict(self):
+            return self.__dict__
+        
+        @classmethod
+        def from_dict(cls, data):
+            return cls(**data)
+    
+    class SettingsManager:
+        def __init__(self):
+            self.CONFIG_FOLDER_NAME = '.lcs_config'
+            self.CONFIG_FILE_NAME = 'config.json'
+            self.config_path = self.get_config_path()
+        
+        def get_config_path(self):
+            config_folder = Path.home().joinpath(self.CONFIG_FOLDER_NAME)
+            config_folder.mkdir(parents=True, exist_ok=True)
+            return config_folder.joinpath(self.CONFIG_FILE_NAME)
+        
+        def load_config(self):
+            if not self.config_path.is_file():
+                return None
+            try:
+                with open(self.config_path, 'r') as f:
+                    config_data = json.load(f)
+                return Config.from_dict(config_data)
+            except (FileNotFoundError, json.JSONDecodeError):
+                return None
+        
+        def save_config(self, config):
+            with open(self.config_path, 'w') as f:
+                json.dump(config.to_dict(), f, indent=2)
+            # Restrict file permissions on non-Windows
+            if platform.system().lower() != 'windows':
+                os.chmod(self.config_path, 0o600)
+
+
+def log(message, quiet=False):
+    """Print message unless quiet mode is enabled."""
+    if not quiet:
+        print(message)
+
+
+def log_error(message):
+    """Always print errors to stderr."""
+    print(f"ERROR: {message}", file=sys.stderr)
+
+
+def get_hidapi_executable():
+    """Get platform-specific hidapitester binary path."""
+    import platform
+    system = platform.system().lower()
+    arch = platform.machine()
+    
+    if system == 'windows':
+        return get_absolute_file_data_path('hidapitester', 'hidapitester-windows-x86_64.exe')
+    elif system == 'darwin':
+        name = 'hidapitester-macos-arm64' if arch == 'arm64' else 'hidapitester-macos-x86_64'
+        return get_absolute_file_data_path('hidapitester', name)
+    else:
+        name = 'hidapitester-linux-armv7l' if arch == 'armv7l' else 'hidapitester-linux-x86_64'
+        return get_absolute_file_data_path('hidapitester', name)
+
+
+def build_hidapi_command(config, msg_bytes):
+    """Build hidapitester command for sending HID++ packet.
+    
+    Args:
+        config: Config object with VENDOR_ID, PRODUCT_ID, PROTOCOL
+        msg_bytes: list of bytes to send
+    
+    Returns:
+        List of command arguments for subprocess
+    """
+    exec_path = get_hidapi_executable()
+    hex_string = ','.join(f'0x{byte:02X}' for byte in msg_bytes)
+    length = str(len(msg_bytes))
+    usage = '2' if config.PROTOCOL == 'bolt' else '1'
+    
+    cmd = [
+        exec_path,
+        '--vidpid', f'{config.VENDOR_ID:04X}:{config.PRODUCT_ID:04X}',
+        '--usage', usage,
+        '--usagePage', '0xFF00',
+        '--open',
+        '--length', length,
+        '--send-output', hex_string,
+        '--length', length,
+        '--send-output', hex_string,  # Send twice for device wake
+    ]
+    return cmd
+
+
+def send_hid_command(config, msg_bytes, max_retries=3, quiet=False):
+    """Send HID command with retries.
+    
+    Args:
+        config: Config object
+        msg_bytes: list of bytes to send
+        max_retries: maximum number of retry attempts
+        quiet: suppress output if True
+    
+    Returns:
+        True if successful, False otherwise
+    """
+    cmd = build_hidapi_command(config, msg_bytes)
+    success_msg = f"wrote {len(msg_bytes)} bytes"
+    
+    for attempt in range(1, max_retries + 1):
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                creationflags=creation_flags
+            )
+            
+            if success_msg in result.stdout:
+                return True
+            
+            # Retry with delay if not last attempt
+            if attempt < max_retries:
+                time.sleep(0.1)
+                
+        except subprocess.TimeoutExpired:
+            log(f"  Timeout on attempt {attempt}/{max_retries}", quiet)
+            if attempt < max_retries:
+                time.sleep(0.1)
+        except Exception as e:
+            log(f"  Error on attempt {attempt}/{max_retries}: {e}", quiet)
+            if attempt < max_retries:
+                time.sleep(0.1)
+    
+    return False
+
+
+def build_channel_switch_packet(config, device_type, channel):
+    """Build HID++ packet for switching channels.
+    
+    Args:
+        config: Config object with protocol and device settings
+        device_type: 'keyboard' or 'mouse'
+        channel: target channel (1, 2, or 3)
+    
+    Returns:
+        List of bytes representing the HID++ packet
+    """
+    # Get device-specific slot and feature index
+    if device_type == 'keyboard':
+        receiver_slot = config.KB_RECEIVER_SLOT
+        feature_index = config.KEYBOARD_ID
+    else:  # mouse
+        receiver_slot = config.MS_RECEIVER_SLOT
+        feature_index = config.MOUSE_ID
+    
+    # Convert channel to zero-indexed (1→0, 2→1, 3→2)
+    channel_byte = channel - 1
+    
+    # Build packet based on protocol
+    if config.PROTOCOL == 'bolt':
+        # Bolt: 20 bytes, report ID 0x11, function 0x1E
+        packet = [0x11, receiver_slot, feature_index, 0x1E, channel_byte] + [0x00] * 15
+    else:
+        # Unifying: 7 bytes, report ID 0x10, function 0x1C
+        packet = [0x10, receiver_slot, feature_index, 0x1C, channel_byte, 0x00, 0x00]
+    
+    return packet
+
+
+def switch_channel(config, channel, quiet=False):
+    """Switch both keyboard and mouse to target channel.
+    
+    Args:
+        config: Config object with device settings
+        channel: target channel (1, 2, or 3)
+        quiet: suppress output if True
+    
+    Returns:
+        True if both devices switched successfully, False otherwise
+    """
+    log(f"Switching to channel {channel}...", quiet)
+    
+    # Switch keyboard
+    log("  Switching keyboard...", quiet)
+    kb_packet = build_channel_switch_packet(config, 'keyboard', channel)
+    kb_success = send_hid_command(config, kb_packet, max_retries=3, quiet=quiet)
+    
+    if not kb_success:
+        log_error("Failed to switch keyboard")
+        return False
+    
+    log("  Keyboard switched", quiet)
+    
+    # Switch mouse
+    log("  Switching mouse...", quiet)
+    ms_packet = build_channel_switch_packet(config, 'mouse', channel)
+    ms_success = send_hid_command(config, ms_packet, max_retries=3, quiet=quiet)
+    
+    if not ms_success:
+        log_error("Failed to switch mouse")
+        return False
+    
+    log("  Mouse switched", quiet)
+    log(f"Successfully switched to channel {channel}", quiet)
+    return True
+
+
+def validate_config(config):
+    """Validate that config has all required fields.
+    
+    Args:
+        config: Config object to validate
+    
+    Returns:
+        (valid: bool, error_message: str or None)
+    """
+    required_fields = [
+        'PROTOCOL', 'VENDOR_ID', 'PRODUCT_ID',
+        'KB_RECEIVER_SLOT', 'MS_RECEIVER_SLOT',
+        'KEYBOARD_ID', 'MOUSE_ID'
+    ]
+    
+    for field in required_fields:
+        if not hasattr(config, field):
+            return False, f"Missing required field: {field}"
+        if getattr(config, field) is None:
+            return False, f"Field {field} is None"
+    
+    # Validate protocol value
+    if config.PROTOCOL not in ['bolt', 'unifying']:
+        return False, f"Invalid PROTOCOL: {config.PROTOCOL} (must be 'bolt' or 'unifying')"
+    
+    return True, None
+
+
+def run_device_discovery(quiet=False):
+    """Run interactive device discovery to generate config.
+    
+    Args:
+        quiet: If True, auto-configure using first two devices found
+    
+    Returns:
+        Config object if successful, None otherwise
+    """
+    if not quiet:
+        print("\n" + "="*70)
+        print("FIRST RUN: Device Discovery")
+        print("="*70)
+        print("\nNo configuration found. Starting device discovery...")
+        print("This will scan your Logitech receiver for paired devices.\n")
+    
+    # Import probe_devices functions
+    sys.path.insert(0, os.path.dirname(__file__))
+    try:
+        from probe_devices import (
+            get_hidapitester, ping_device, query_feature_index
+        )
+    except ImportError as e:
+        if not quiet:
+            log_error(f"Failed to import probe_devices: {e}")
+        return None
+    
+    # Auto-detect protocol and VID:PID in quiet mode, or prompt in interactive mode
+    if quiet:
+        # Try Bolt first (more common on newer receivers)
+        protocol = "bolt"
+        vidpid_input = "046D:C548"
+        vendor_id = 0x046D
+        product_id = 0xC548
+    else:
+        # Prompt for protocol
+        print("Select receiver protocol:")
+        print("  1 = Bolt (default, newer receivers)")
+        print("  2 = Unifying (older receivers)")
+        protocol_choice = input("Enter choice [1]: ").strip() or "1"
+        
+        if protocol_choice == "2":
+            protocol = "unifying"
+            default_vidpid = "046D:C52B"
+        else:
+            protocol = "bolt"
+            default_vidpid = "046D:C548"
+        
+        print(f"\nUsing protocol: {protocol}")
+        
+        # Prompt for VID:PID (allow override)
+        vidpid_input = input(f"Enter VID:PID [{default_vidpid}]: ").strip() or default_vidpid
+        
+        # Parse VID:PID
+        try:
+            vid_str, pid_str = vidpid_input.split(':')
+            vendor_id = int(vid_str, 16)
+            product_id = int(pid_str, 16)
+        except:
+            log_error(f"Invalid VID:PID format: {vidpid_input}")
+            return None
+        
+        print(f"\nScanning receiver {vidpid_input}...")
+    
+    # Get hidapitester path
+    exec_path = get_hidapitester()
+    
+    # Step 1: Ping device indices 0-8
+    if not quiet:
+        print("\nStep 1: Discovering paired devices...")
+        print("(This scans receiver slots 0-8 for active devices)")
+    
+    devices = []
+    for dev_idx in range(0, 9):
+        if not quiet:
+            sys.stdout.write(f'\r  Checking slot {dev_idx}...')
+            sys.stdout.flush()
+        ok, output, response = ping_device(exec_path, vidpid_input, protocol, dev_idx)
+        if ok:
+            if not quiet:
+                sys.stdout.write(f'\r  Slot {dev_idx}: ✅ DEVICE FOUND   \n')
+            devices.append(dev_idx)
+        else:
+            if not quiet:
+                sys.stdout.write(f'\r  Slot {dev_idx}: -              \n')
+    
+    if not devices:
+        if not quiet:
+            log_error("\n⚠️  No devices found. Please check:")
+            log_error("  - Receiver is plugged in and recognized by your computer")
+            log_error("  - Keyboard/mouse are turned ON and paired to this receiver")
+            log_error(f"  - VID:PID {vidpid_input} matches your receiver")
+            log_error(f"  - Protocol '{protocol}' matches your receiver type")
+            log_error("\n💡 TIP: Try running 'python probe_devices.py' for more details")
+        return None
+    
+    # In quiet mode, try Unifying if Bolt didn't find devices
+    if quiet and not devices and protocol == "bolt":
+        protocol = "unifying"
+        vidpid_input = "046D:C52B"
+        vendor_id = 0x046D
+        product_id = 0xC52B
+        
+        # Retry with Unifying protocol
+        devices = []
+        for dev_idx in range(0, 9):
+            ok, output, response = ping_device(exec_path, vidpid_input, protocol, dev_idx)
+            if ok:
+                devices.append(dev_idx)
+        
+        if not devices:
+            return None
+    
+    if not quiet:
+        print(f"\n✅ Found {len(devices)} device(s) at slot(s): {', '.join(map(str, devices))}")
+    
+    # Step 2: Query Change Host feature for each device
+    CHANGE_HOST = 0x1814
+    if not quiet:
+        print("\nStep 2: Querying Change Host feature...")
+    
+    results = []
+    for dev_idx in devices:
+        if not quiet:
+            sys.stdout.write(f'  Device slot {dev_idx}: ')
+            sys.stdout.flush()
+        feat_idx, _ = query_feature_index(exec_path, vidpid_input, protocol, dev_idx, CHANGE_HOST)
+        if feat_idx and feat_idx > 0:
+            if not quiet:
+                print(f'✅ Change Host found at feature index {feat_idx} (0x{feat_idx:02X})')
+            results.append((dev_idx, feat_idx))
+        else:
+            if not quiet:
+                print('❌ Change Host not found (device does not support channel switching)')
+    
+    if not results:
+        if not quiet:
+            log_error("\n⚠️  No devices with Change Host support found.")
+            log_error("Your devices may not support channel switching.")
+            log_error("Ensure your keyboard/mouse have multi-device/multi-channel capability.")
+        return None
+    
+    if len(results) < 2:
+        if not quiet:
+            log_error(f"\n⚠️  Only found {len(results)} device with Change Host support.")
+            log_error("You need both a keyboard AND mouse paired to the receiver.")
+            log_error("\nPossible solutions:")
+            log_error("  1. Pair your second device to the receiver")
+            log_error("  2. Turn on the device if it's off")
+            log_error("  3. Check if both devices support multi-device switching")
+        return None
+    
+    # Auto-configure in quiet mode: first device = keyboard, second = mouse
+    if quiet:
+        kb_receiver_slot, kb_feature_idx = results[0]
+        ms_receiver_slot, ms_feature_idx = results[1]
+        
+        # Create config directly without user interaction
+        config = Config(
+            PROTOCOL=protocol,
+            VENDOR_ID=vendor_id,
+            PRODUCT_ID=product_id,
+            KB_RECEIVER_SLOT=kb_receiver_slot,
+            MS_RECEIVER_SLOT=ms_receiver_slot,
+            KEYBOARD_ID=kb_feature_idx,
+            MOUSE_ID=ms_feature_idx
+        )
+        return config
+    
+    # Step 3: Interactive device assignment (only in non-quiet mode)
+    print("\n" + "="*70)
+    print("Step 3: Device Assignment")
+    print("="*70)
+    print("\n📋 DEVICES FOUND:")
+    for i, (dev_idx, feat_idx) in enumerate(results, 1):
+        print(f"  {i}. Device at receiver slot {dev_idx} | Change Host feature index: {feat_idx} (0x{feat_idx:02X})")
+    
+    print("\n💡 NOTE: It's normal for devices to have the same feature index.")
+    print("   What matters is the SLOT number (1 vs 2), which identifies each device.")
+    print("\n💡 TIP: It doesn't actually matter which device you call 'keyboard' or 'mouse'.")
+    print("   Both receive the same channel-switch command. The labels are just for clarity.")
+    
+    print("\n🔍 HELP: Not sure which device is which?")
+    print("   Option 1: Usually, the first device paired (lower slot) is the keyboard")
+    print("   Option 2: Test each device individually below (sends command to see which responds)")
+    print("   Option 3: Just pick any assignment - it will still work! 😊")
+    
+    test_choice = input("\n🧪 Would you like to test each device before choosing? [y/N]: ").strip().lower()
+    
+    kb_from_test = None
+    ms_from_test = None
+    
+    if test_choice in ['y', 'yes']:
+        print("\n" + "="*70)
+        print("🧪 DEVICE TESTING MODE")
+        print("="*70)
+        print("\nWe'll send a channel switch command to each device.")
+        print("Watch your keyboard and mouse to see which one responds.\n")
+        
+        # Ask what channel devices are currently on
+        print("💡 TIP: For the test to work, we need to switch to a DIFFERENT channel")
+        print("        than the one your devices are currently on.\n")
+        
+        while True:
+            current_channel = input("What channel are your devices currently on? [1/2/3]: ").strip()
+            if current_channel in ['1', '2', '3']:
+                current_channel = int(current_channel)
+                break
+            else:
+                print("❌ Please enter 1, 2, or 3")
+        
+        # Choose a different channel for testing
+        test_channel = 2 if current_channel == 1 else 1
+        print(f"\n✅ Current channel: {current_channel}")
+        print(f"✅ Test will switch devices to channel {test_channel} (so you can see the change)\n")
+        
+        device_labels = {}  # Store what each device is: {dev_idx: 'keyboard'/'mouse'/None}
+        
+        for i, (dev_idx, feat_idx) in enumerate(results, 1):
+            print(f"\n--- Testing Device {i} (Slot {dev_idx}, Feature Index {feat_idx}) ---")
+            input("Press ENTER to send test command to this device...")
+            
+            # Create temporary config for this device
+            test_config = Config(
+                PROTOCOL=protocol,
+                VENDOR_ID=vendor_id,
+                PRODUCT_ID=product_id,
+                KB_RECEIVER_SLOT=dev_idx,
+                MS_RECEIVER_SLOT=dev_idx,
+                KEYBOARD_ID=feat_idx,
+                MOUSE_ID=feat_idx
+            )
+            
+            # Try to switch to test channel (different from current)
+            print(f"  📡 Sending switch to channel {test_channel}...")
+            packet = build_channel_switch_packet(test_config, 'keyboard', test_channel)
+            success = send_hid_command(test_config, packet, max_retries=2, quiet=True)
+            
+            if success:
+                print(f"  ✅ Command sent successfully")
+                print(f"  👀 Did your keyboard or mouse switch to channel {test_channel}?")
+                device_type = input(f"     What device is this? [k=keyboard, m=mouse, s=skip]: ").strip().lower()
+                
+                if device_type == 'k':
+                    device_labels[dev_idx] = 'keyboard'
+                    print(f"  ✅ Marked as KEYBOARD")
+                elif device_type == 'm':
+                    device_labels[dev_idx] = 'mouse'
+                    print(f"  ✅ Marked as MOUSE")
+                else:
+                    device_labels[dev_idx] = None
+                    print(f"  ⏭️  Skipped")
+            else:
+                print(f"  ❌ Command failed (device may be off or not responding)")
+                device_labels[dev_idx] = None
+        
+        # Check if user identified both devices during testing
+        for dev_idx, feat_idx in results:
+            if device_labels.get(dev_idx) == 'keyboard':
+                kb_from_test = (dev_idx, feat_idx)
+            elif device_labels.get(dev_idx) == 'mouse':
+                ms_from_test = (dev_idx, feat_idx)
+        
+        if kb_from_test is not None and ms_from_test is not None:
+            kb_receiver_slot, kb_feature_idx = kb_from_test
+            ms_receiver_slot, ms_feature_idx = ms_from_test
+            
+            print("\n" + "="*70)
+            print("✅ Devices identified from testing:")
+            print(f"   Keyboard: Slot {kb_receiver_slot}, Feature Index {kb_feature_idx}")
+            print(f"   Mouse:    Slot {ms_receiver_slot}, Feature Index {ms_feature_idx}")
+            
+            confirm = input("\nUse these settings? [Y/n]: ").strip().lower()
+            if confirm in ['n', 'no']:
+                kb_from_test = None
+                ms_from_test = None
+    
+    # Manual selection if test was skipped or user rejected test results
+    if kb_from_test is None or ms_from_test is None:
+        print("\n" + "-"*70)
+        print("Which device is your KEYBOARD?")
+        for i, (dev_idx, feat_idx) in enumerate(results, 1):
+            print(f"  {i} = Slot {dev_idx} (feature index {feat_idx})")
+        
+        while True:
+            kb_choice = input(f"\nEnter number [1-{len(results)}]: ").strip()
+            try:
+                kb_idx = int(kb_choice) - 1
+                if 0 <= kb_idx < len(results):
+                    kb_receiver_slot, kb_feature_idx = results[kb_idx]
+                    break
+                else:
+                    print(f"❌ Invalid choice. Enter a number between 1 and {len(results)}")
+            except ValueError:
+                print("❌ Invalid input. Enter a number.")
+        
+        print(f"✅ Keyboard set to: Slot {kb_receiver_slot}, Feature Index {kb_feature_idx}")
+        
+        print("\n" + "-"*70)
+        print("Which device is your MOUSE?")
+        for i, (dev_idx, feat_idx) in enumerate(results, 1):
+            if i == kb_idx + 1:
+                print(f"  {i} = Slot {dev_idx} (feature index {feat_idx}) [ALREADY USED AS KEYBOARD]")
+            else:
+                print(f"  {i} = Slot {dev_idx} (feature index {feat_idx})")
+        
+        while True:
+            ms_choice = input(f"\nEnter number [1-{len(results)}]: ").strip()
+            try:
+                ms_idx = int(ms_choice) - 1
+                if 0 <= ms_idx < len(results):
+                    ms_receiver_slot, ms_feature_idx = results[ms_idx]
+                    if ms_receiver_slot == kb_receiver_slot:
+                        print("❌ Cannot use the same device for both keyboard and mouse!")
+                        print(f"   You already selected slot {kb_receiver_slot} as the keyboard.")
+                        print("   Please choose a different device.")
+                        continue
+                    break
+                else:
+                    print(f"❌ Invalid choice. Enter a number between 1 and {len(results)}")
+            except ValueError:
+                print("❌ Invalid input. Enter a number.")
+        
+        print(f"✅ Mouse set to: Slot {ms_receiver_slot}, Feature Index {ms_feature_idx}")
+    else:
+        # Use settings from test
+        kb_receiver_slot, kb_feature_idx = kb_from_test
+        ms_receiver_slot, ms_feature_idx = ms_from_test
+        print("\n✅ Using settings from device testing")
+    
+    # Create config
+    print("\n" + "="*70)
+    print("Configuration Summary")
+    print("="*70)
+    print(f"  Protocol:     {protocol}")
+    print(f"  VID:PID:      {vidpid_input}")
+    print(f"  Keyboard:     Slot {kb_receiver_slot}, Feature Index {kb_feature_idx} (0x{kb_feature_idx:02X})")
+    print(f"  Mouse:        Slot {ms_receiver_slot}, Feature Index {ms_feature_idx} (0x{ms_feature_idx:02X})")
+    
+    # Note about same feature index
+    if kb_feature_idx == ms_feature_idx:
+        print(f"\n  ℹ️  Note: Both devices use feature index {kb_feature_idx}. This is normal!")
+        print(f"      The SLOT number ({kb_receiver_slot} vs {ms_receiver_slot}) identifies each device.")
+    
+    # Critical validation: same slot means same device!
+    if kb_receiver_slot == ms_receiver_slot:
+        log_error("\n❌ ERROR: Keyboard and mouse are assigned to the SAME SLOT!")
+        log_error(f"   Both are using slot {kb_receiver_slot}.")
+        log_error("   This means you selected the same device twice.")
+        log_error("\n   The configuration will NOT work correctly.")
+        log_error("   Please run the configuration again and select DIFFERENT devices.")
+        return None
+    
+    print("="*70)
+    
+    # Offer quick test before saving
+    print("\n💡 Would you like to test the configuration before saving?")
+    print("   This will switch both devices to verify they respond correctly.")
+    test_choice = input("Test now? [y/N]: ").strip().lower()
+    
+    if test_choice in ['y', 'yes']:
+        print("\n🧪 Testing configuration...")
+        
+        # Ask current channel
+        while True:
+            current_ch = input("What channel are your devices currently on? [1/2/3]: ").strip()
+            if current_ch in ['1', '2', '3']:
+                current_ch = int(current_ch)
+                break
+            else:
+                print("❌ Please enter 1, 2, or 3")
+        
+        # Choose different channel for test
+        test_ch = 2 if current_ch == 1 else 1
+        print(f"\n✅ Will test by switching to channel {test_ch} (different from current {current_ch})")
+        
+        test_config = Config(
+            PROTOCOL=protocol,
+            VENDOR_ID=vendor_id,
+            PRODUCT_ID=product_id,
+            KB_RECEIVER_SLOT=kb_receiver_slot,
+            MS_RECEIVER_SLOT=ms_receiver_slot,
+            KEYBOARD_ID=kb_feature_idx,
+            MOUSE_ID=ms_feature_idx
+        )
+        
+        print(f"\n  📡 Sending switch to channel {test_ch} for keyboard...")
+        kb_packet = build_channel_switch_packet(test_config, 'keyboard', test_ch)
+        kb_success = send_hid_command(test_config, kb_packet, max_retries=3, quiet=True)
+        
+        print(f"  📡 Sending switch to channel {test_ch} for mouse...")
+        ms_packet = build_channel_switch_packet(test_config, 'mouse', test_ch)
+        ms_success = send_hid_command(test_config, ms_packet, max_retries=3, quiet=True)
+        
+        if kb_success and ms_success:
+            print(f"\n✅ Test successful! Both devices should now be on channel {test_ch}.")
+            print("   If your keyboard/mouse switched channels, the configuration is correct.")
+            print(f"\n💡 Note: Devices are now on channel {test_ch}. You can switch them back manually")
+            print(f"   or save this config and use it to switch to any channel.")
+        else:
+            print("\n⚠️  Test failed!")
+            if not kb_success:
+                print("   - Keyboard switch command failed")
+            if not ms_success:
+                print("   - Mouse switch command failed")
+            confirm = input("\nDo you want to save this configuration anyway? [y/N]: ").strip().lower()
+            if confirm not in ['y', 'yes']:
+                log_error("Configuration cancelled.")
+                return None
+    
+    config = Config(
+        PROTOCOL=protocol,
+        VENDOR_ID=vendor_id,
+        PRODUCT_ID=product_id,
+        KB_RECEIVER_SLOT=kb_receiver_slot,
+        MS_RECEIVER_SLOT=ms_receiver_slot,
+        KEYBOARD_ID=kb_feature_idx,
+        MOUSE_ID=ms_feature_idx
+    )
+    
+    return config
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description='Logitech Channel Switcher CLI - Switch keyboard/mouse channels',
+        epilog='For first-run setup, run without --quiet to configure devices.'
+    )
+    parser.add_argument(
+        '--channel',
+        type=int,
+        required=True,
+        choices=[1, 2, 3],
+        help='Target channel (1, 2, or 3)'
+    )
+    parser.add_argument(
+        '--quiet',
+        action='store_true',
+        help='Suppress output (for use in shortcuts)'
+    )
+    
+    args = parser.parse_args()
+    
+    # Load or create configuration
+    settings_manager = SettingsManager()
+    config = settings_manager.load_config()
+    
+    if config is None:
+        # No config exists - run device discovery
+        config = run_device_discovery(quiet=args.quiet)
+        if config is None:
+            # Discovery failed
+            sys.exit(1)
+        
+        # Save the new config
+        try:
+            settings_manager.save_config(config)
+            log(f"\nConfiguration saved to: {settings_manager.config_path}", args.quiet)
+        except Exception as e:
+            log_error(f"Failed to save configuration: {e}")
+            sys.exit(1)
+    
+    # Validate configuration
+    valid, error_msg = validate_config(config)
+    if not valid:
+        log_error(f"Invalid configuration: {error_msg}")
+        log_error(f"Please check: {settings_manager.config_path}")
+        sys.exit(1)
+    
+    # Switch channels
+    success = switch_channel(config, args.channel, quiet=args.quiet)
+    
+    if success:
+        sys.exit(0)
+    else:
+        sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/probe_devices.py
+++ b/tools/probe_devices.py
@@ -20,142 +20,12 @@ import os
 VERSION = '0.5'
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
-from utils import get_absolute_file_data_path, creation_flags
-
-
-def get_hidapitester():
-    import platform
-    system = platform.system().lower()
-    arch = platform.machine()
-    if system == 'windows':
-        return get_absolute_file_data_path('hidapitester', 'hidapitester-windows-x86_64.exe')
-    elif system == 'darwin':
-        name = 'hidapitester-macos-arm64' if arch == 'arm64' else 'hidapitester-macos-x86_64'
-        return get_absolute_file_data_path('hidapitester', name)
-    else:
-        name = 'hidapitester-linux-armv7l' if arch == 'armv7l' else 'hidapitester-linux-x86_64'
-        return get_absolute_file_data_path('hidapitester', name)
-
-
-def hid_send_receive(exec_path, vidpid, protocol, msg, force_short=False):
-    """Send a HID++ message and return (success, raw_output, response_bytes).
-
-    force_short: use short endpoint (usage 1, 7 bytes) even for Bolt.
-    """
-    if force_short or protocol != 'bolt':
-        if len(msg) < 7:
-            msg = msg + [0x00] * (7 - len(msg))
-        length = '7'
-        usage = '1'
-    else:
-        if len(msg) < 20:
-            msg = msg + [0x00] * (20 - len(msg))
-        length = '20'
-        usage = '2'
-
-    hex_string = ','.join(f'0x{b:02X}' for b in msg)
-    cmd = [
-        exec_path, '--vidpid', vidpid,
-        '--usage', usage, '--usagePage', '0xFF00', '--open',
-        '--length', length, '--send-output', hex_string,
-        '--length', length, '--send-output', hex_string,
-        '--timeout', '2000',
-        '--length', length, '--read-input',
-    ]
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True,
-                                timeout=3, creationflags=creation_flags)
-        output = result.stdout + result.stderr
-        # Parse response bytes from output
-        response = parse_response_bytes(output)
-        if response:
-            return True, output, response
-        # Fallback: check if hidapitester read any bytes (even if not printed)
-        if 'read 7 bytes' in output or 'read 20 bytes' in output:
-            return True, output, None
-        return False, output, None
-    except subprocess.TimeoutExpired:
-        return False, 'timeout', None
-    except Exception as e:
-        return False, str(e), None
-
-
-def parse_response_bytes(output):
-    """Extract response bytes from hidapitester read output.
-
-    hidapitester format:
-        Reading N-byte input report ...read N bytes:
-         AA BB CC DD ...
-    Hex bytes are on the NEXT line after 'read N bytes:'.
-    """
-    lines = output.split('\n')
-    for i, line in enumerate(lines):
-        if 'read' in line and 'bytes' in line and 'read 0 bytes' not in line:
-            # Check same line after colon
-            parts = line.split(':')
-            if len(parts) > 1:
-                hex_part = parts[-1].strip()
-                if hex_part:
-                    try:
-                        return [int(b, 16) for b in hex_part.split()]
-                    except ValueError:
-                        pass
-            # Check next line for hex bytes
-            if i + 1 < len(lines):
-                next_line = lines[i + 1].strip()
-                if next_line:
-                    try:
-                        return [int(b, 16) for b in next_line.split()]
-                    except ValueError:
-                        pass
-    return None
-
-
-def ping_device(exec_path, vidpid, protocol, device_index):
-    """HID++ 2.0 ping: IRoot (feature 0x00), function 1 (ping), swID=0x0F.
-
-    Tries short endpoint first. For Bolt, also tries long endpoint if short
-    returns no data (Bolt devices may only respond on the long endpoint).
-    """
-    # Try short ping first
-    msg_short = [0x10, device_index, 0x00, 0x1F, 0x00, 0x00, 0xAA]
-    ok, output, response = hid_send_receive(exec_path, vidpid, protocol, msg_short, force_short=True)
-    if ok:
-        # Check if it's an error response (0x8F = HID++ error, not a real device)
-        if response and len(response) >= 3 and response[2] == 0x8F:
-            return False, output, response
-        return True, output, response
-
-    # For Bolt, try long endpoint if short didn't work
-    if protocol == 'bolt':
-        msg_long = [0x11, device_index, 0x00, 0x1F] + [0x00] * 15 + [0xAA]
-        ok, output, response = hid_send_receive(exec_path, vidpid, protocol, msg_long)
-        if ok:
-            if response and len(response) >= 3 and response[2] == 0x8F:
-                return False, output, response
-            return True, output, response
-
-    return False, output, response
-
-
-def query_feature_index(exec_path, vidpid, protocol, device_index, feature_id):
-    """Query IRoot.getFeature(featureID) to find a feature's index.
-
-    IRoot is always at feature index 0x00, function 0 = getFeature.
-    Sends [report_id, device_index, 0x00, 0x0F, feat_hi, feat_lo, ...]
-    Response byte 4 contains the feature index (0 = not found).
-    """
-    feat_hi = (feature_id >> 8) & 0xFF
-    feat_lo = feature_id & 0xFF
-    if protocol == 'bolt':
-        msg = [0x11, device_index, 0x00, 0x0F, feat_hi, feat_lo]
-    else:
-        msg = [0x10, device_index, 0x00, 0x0F, feat_hi, feat_lo]
-
-    ok, output, response = hid_send_receive(exec_path, vidpid, protocol, msg)
-    if ok and response and len(response) > 4:
-        return response[4], output  # feature index
-    return None, output
+from hid_protocol import (
+    get_hidapi_executable,
+    ping_device,
+    query_feature_index,
+    FEATURE_CHANGE_HOST
+)
 
 
 def main():
@@ -178,7 +48,7 @@ def main():
     if protocol == 'unifying' and vidpid == '046D:C548':
         vidpid = '046D:C52B'
 
-    exec_path = get_hidapitester()
+    exec_path = get_hidapi_executable()
     print(f'Probe v{VERSION} — Probing receiver {vidpid} (protocol: {protocol})')
     print(f'Using: {exec_path}')
 
@@ -208,13 +78,12 @@ def main():
         return
 
     # Step 2: Query Change Host (0x1814) feature index for each device
-    CHANGE_HOST = 0x1814
     print(f'\n--- Step 2: Querying Change Host (0x1814) feature index ---\n')
     results = []
     for dev_idx in devices:
         sys.stdout.write(f'  Device index {dev_idx}: ')
         sys.stdout.flush()
-        feat_idx, query_output = query_feature_index(exec_path, vidpid, protocol, dev_idx, CHANGE_HOST)
+        feat_idx, query_output = query_feature_index(exec_path, vidpid, protocol, dev_idx, FEATURE_CHANGE_HOST)
         if feat_idx and feat_idx > 0:
             print(f'Change Host feature at index {feat_idx} (0x{feat_idx:02X})')
             results.append((dev_idx, feat_idx))

--- a/tools/shortcuts/README.md
+++ b/tools/shortcuts/README.md
@@ -1,0 +1,344 @@
+# Keyboard Shortcuts for LCS CLI
+
+This directory contains helper scripts for creating global keyboard shortcuts to switch Logitech channels instantly.
+
+## ⚠️ IMPORTANT: First-Time Setup
+
+**The silent shortcuts will auto-configure on first run!**
+
+When you run a shortcut for the first time without configuration, it will:
+1. **Automatically detect** your Logitech receiver (tries Bolt, then Unifying)
+2. **Auto-assign** first device found as keyboard, second as mouse
+3. **Save configuration** to `%USERPROFILE%\.lcs_config\config.json`
+4. **Switch channels** immediately
+
+### If You Want Manual Control
+
+If you prefer to choose which device is keyboard/mouse (though it doesn't functionally matter):
+
+### Windows
+1. Double-click **`configure.bat`** in this directory
+2. Follow the interactive prompts to select your protocol and identify your devices
+3. Configuration will be saved to `%USERPROFILE%\.lcs_config\config.json`
+
+### Linux/macOS
+```bash
+cd tools/shortcuts
+./configure.sh
+# Or: chmod +x configure.sh && ./configure.sh
+```
+
+**Why auto-config works:** The first device paired is usually the keyboard, second is the mouse. And even if they're swapped, both receive the same channel-switch command, so it works either way!
+
+---
+
+## Overview
+
+The scripts in this directory provide silent, background execution of the CLI switcher without console windows. Each script switches to a specific channel (1, 2, or 3).
+
+**Available Scripts:**
+- **`configure.bat` / `configure.sh`** — **Run this FIRST** (setup/reconfiguration)
+- `switch-channel-1.bat` / `switch-channel-1.sh` — Switch to Channel 1
+- `switch-channel-2.bat` / `switch-channel-2.sh` — Switch to Channel 2
+- `switch-channel-3.bat` / `switch-channel-3.sh` — Switch to Channel 3
+
+---
+
+## Windows Setup
+
+### Method 1: Create Desktop Shortcuts (Recommended)
+
+1. **Right-click** on the desired `.bat` file (e.g., `switch-channel-1.bat`)
+2. Select **"Create shortcut"**
+3. **Drag the shortcut** to your Desktop or Start Menu
+4. **Right-click the shortcut** > **Properties**
+5. Click in the **"Shortcut key"** field
+6. **Press your desired key combination** (e.g., `Ctrl+Alt+1`)
+   - Windows will automatically prefix it (e.g., shows as `Ctrl + Alt + 1`)
+7. Click **OK**
+
+**Repeat for channels 2 and 3** with different key combinations (e.g., `Ctrl+Alt+2`, `Ctrl+Alt+3`).
+
+### Method 2: Pin to Taskbar
+
+1. **Right-click** the `.bat` file > **"Create shortcut"**
+2. **Right-click the shortcut** > **"Pin to taskbar"**
+3. Once pinned, press **Win + [Number]** to trigger (Win+1 for first icon, etc.)
+
+### Troubleshooting Windows
+
+- **First run takes longer:** Auto-detection scans for devices (5-10 seconds). Subsequent runs are instant.
+- **Exit code 1 without doing anything:** Auto-detection failed. Run `configure.bat` (Windows) or `configure.sh` (Linux/macOS) to see error messages.
+- **Console window flashes:** Ensure you're using `pythonw.exe` (not `python.exe`). The provided `.bat` files already use `pythonw.exe`.
+- **Shortcut doesn't work:** 
+  - Verify Python is installed and in PATH
+  - Try running the `.bat` file directly first (double-click)
+  - Check that the configuration file exists: `%USERPROFILE%\.lcs_config\config.json`
+  - Try running `configure.bat` (Windows) or `configure.sh` (Linux/macOS) to see detailed error messages
+- **"pythonw.exe not found":**
+  - Add Python to your PATH, or
+  - Edit the `.bat` file to use the full path: `C:\Python39\pythonw.exe`
+---
+
+## Linux Setup
+
+### GNOME (Ubuntu, Fedora, etc.)
+
+1. Open **Settings** > **Keyboard** > **Keyboard Shortcuts** (or **Custom Shortcuts**)
+2. Click **"+"** or **"Add Custom Shortcut"**
+3. **Name:** `Switch to Channel 1`
+4. **Command:** `/path/to/lcs/tools/shortcuts/switch-channel-1.sh`
+   - Replace `/path/to/lcs` with your actual repository path
+5. **Shortcut:** Click "Set Shortcut" and press your key combo (e.g., `Ctrl+Alt+1`)
+6. Click **Add**
+
+**Repeat for channels 2 and 3.**
+
+### KDE Plasma
+
+1. Open **System Settings** > **Shortcuts** > **Custom Shortcuts**
+2. Right-click > **New** > **Global Shortcut** > **Command/URL**
+3. **Trigger tab:** Set your key combination (e.g., `Ctrl+Alt+1`)
+4. **Action tab:** Enter `/path/to/lcs/tools/shortcuts/switch-channel-1.sh`
+5. Click **Apply**
+
+**Repeat for channels 2 and 3.**
+
+### Make Scripts Executable
+
+Before using the shell scripts on Linux/macOS, make them executable:
+
+```bash
+cd tools/shortcuts
+chmod +x switch-channel-1.sh
+chmod +x switch-channel-2.sh
+chmod +x switch-channel-3.sh
+```
+
+### Using xbindkeys (Alternative)
+
+If your desktop environment doesn't support custom shortcuts, use `xbindkeys`:
+
+1. Install xbindkeys:
+   ```bash
+   sudo apt install xbindkeys  # Debian/Ubuntu
+   sudo dnf install xbindkeys  # Fedora
+   ```
+
+2. Create config file:
+   ```bash
+   xbindkeys --defaults > ~/.xbindkeysrc
+   ```
+
+3. Edit `~/.xbindkeysrc` and add:
+   ```
+   "/path/to/lcs/tools/shortcuts/switch-channel-1.sh"
+       Control+Alt + 1
+   
+   "/path/to/lcs/tools/shortcuts/switch-channel-2.sh"
+       Control+Alt + 2
+   
+   "/path/to/lcs/tools/shortcuts/switch-channel-3.sh"
+       Control+Alt + 3
+   ```
+
+4. Restart xbindkeys:
+   ```bash
+   killall xbindkeys
+   xbindkeys
+   ```
+
+5. Add xbindkeys to startup applications
+
+### Troubleshooting Linux
+
+- **"Permission denied":** Run `chmod +x switch-channel-*.sh`
+- **"python3: command not found":** Install Python 3 or edit scripts to use full path
+- **HID access denied:** 
+  - On Linux, you may need `sudo` for HID access
+  - Add udev rules to allow non-root access (see main README)
+  - Or run: `sudo python3 cli_switcher.py --channel 1` (not recommended long-term)
+
+---
+
+## macOS Setup
+
+### Method 1: System Preferences (Monterey and later)
+
+1. Open **System Preferences** > **Keyboard** > **Shortcuts**
+2. Select **App Shortcuts** or **Services** (left sidebar)
+3. Click **"+"** to add a shortcut
+4. **Application:** All Applications
+5. **Command:** Enter the full path to the script:
+   ```
+   /Users/yourusername/path/to/lcs/tools/shortcuts/switch-channel-1.sh
+   ```
+6. **Keyboard Shortcut:** Press your key combo (e.g., `⌃⌥1` = Ctrl+Option+1)
+7. Click **Add**
+
+**Repeat for channels 2 and 3.**
+
+### Method 2: Automator + Keyboard Maestro (Advanced)
+
+For more advanced hotkey management, use [Keyboard Maestro](https://www.keyboardmaestro.com/) or [BetterTouchTool](https://folivora.ai/).
+
+### Make Scripts Executable (macOS)
+
+```bash
+cd tools/shortcuts
+chmod +x switch-channel-1.sh
+chmod +x switch-channel-2.sh
+chmod +x switch-channel-3.sh
+```
+
+### Troubleshooting macOS
+
+- **"Operation not permitted":** 
+  - Grant Terminal (or your script runner) **Accessibility** permissions
+  - System Preferences > Security & Privacy > Privacy > Accessibility
+- **"python3: command not found":** 
+  - Install Python 3 via Homebrew: `brew install python3`
+  - Or use full path in script: `/usr/local/bin/python3`
+
+---
+
+## Advanced Usage
+
+### Custom Key Combinations
+
+You can modify the scripts or create new ones for different workflows:
+
+**Example: Switch channel only if Ctrl is held**
+```batch
+REM Windows: Add timeout check
+if not "%CTRL_KEY_PRESSED%"=="1" exit
+pythonw.exe "%~dp0..\cli_switcher.py" --channel 1 --quiet
+```
+
+### Running Without Shortcuts
+
+You can also run the CLI directly from terminal:
+
+```bash
+# Switch to channel 2
+python cli_switcher.py --channel 2
+
+# Switch silently (no output)
+python cli_switcher.py --channel 1 --quiet
+```
+
+### Exit Codes
+
+The CLI returns specific exit codes for automation:
+- `0` = Success
+- `1` = Configuration error (missing/invalid config)
+- `2` = HID communication failure
+- `3` = Invalid arguments
+
+**Example: Check if switching succeeded**
+```bash
+#!/bin/bash
+python3 cli_switcher.py --channel 2 --quiet
+if [ $? -eq 0 ]; then
+    notify-send "Switched to Channel 2"
+else
+    notify-send "Failed to switch channel"
+fi
+```
+
+---
+
+## First-Run Configuration (Optional)
+
+The shortcuts will **auto-configure on first run**, but if you want manual control:
+
+### Windows
+**Option 1: Using the helper script (Recommended)**
+1. Navigate to `tools\shortcuts\`
+2. Double-click **`configure.bat`**
+3. Follow the interactive prompts
+
+**Option 2: Manual command**
+```powershell
+cd tools
+python cli_switcher.py --channel 1
+```
+
+### Linux/macOS
+**Option 1: Using the helper script (Recommended)**
+```bash
+cd tools/shortcuts
+chmod +x configure.sh
+./configure.sh
+```
+
+**Option 2: Manual command**
+```bash
+cd tools
+python3 cli_switcher.py --channel 1
+```
+
+### Linux/macOS
+```bash
+cd tools
+python3 cli_switcher.py --channel 1
+```
+
+This will launch an interactive setup that:
+1. Lets you choose protocol (Bolt or Unifying)
+2. Scans for paired devices
+3. **Optionally test devices** to identify which is keyboard/mouse
+4. Prompts you to confirm which is your keyboard and which is your mouse
+5. Saves configuration to `~/.lcs_config/config.json`
+
+**Note:** Manual configuration is only needed if:
+- Auto-detection fails (wrong protocol, unusual VID:PID)
+- You want to ensure specific device assignments
+- You want to test devices before saving config
+
+For most users, **just use the shortcuts** - they'll configure automatically!
+
+---
+
+## Security Considerations
+
+### Enterprise/DLP Environments
+
+The CLI switcher is designed for strict enterprise environments:
+
+- ✅ **No background processes** — Runs stateless, exits immediately after switching
+- ✅ **No network communication** — USB/HID access only
+- ✅ **No clipboard sync** — Unlike the GUI app, CLI doesn't use Uniclip
+- ✅ **User-space only** — No admin/sudo required (after udev rules on Linux)
+- ✅ **No persistent memory** — Only reads config file, no telemetry
+
+### Config File Permissions
+
+The configuration file is stored at:
+- **Windows:** `C:\Users\<username>\.lcs_config\config.json`
+- **Linux/macOS:** `~/.lcs_config/config.json` (chmod 600)
+
+The file contains only device hardware identifiers (VID, PID, receiver slots, feature indices). No passwords or sensitive data.
+
+---
+
+## Uninstallation
+
+To remove keyboard shortcuts:
+
+**Windows:**
+1. Delete the shortcut files you created
+2. Or right-click shortcut > Properties > Clear "Shortcut key" field
+
+**Linux (GNOME/KDE):**
+1. Open Settings > Keyboard > Custom Shortcuts
+2. Select and delete the LCS shortcuts
+
+**macOS:**
+1. System Preferences > Keyboard > Shortcuts
+2. Select and delete the LCS shortcuts
+
+To remove the CLI config file:
+```bash
+rm -rf ~/.lcs_config
+```

--- a/tools/shortcuts/configure.bat
+++ b/tools/shortcuts/configure.bat
@@ -1,0 +1,47 @@
+@echo off
+REM Logitech Channel Switcher - Configure Devices
+REM Run this script to set up your keyboard and mouse assignment
+
+echo ======================================================================
+echo  Logitech Channel Switcher - CONFIGURATION
+echo ======================================================================
+echo.
+
+REM Check if config already exists
+if exist "%USERPROFILE%\.lcs_config\config.json" (
+    echo Configuration already exists at:
+    echo %USERPROFILE%\.lcs_config\config.json
+    echo.
+    set /p RECONFIGURE="Do you want to reconfigure? (y/n): "
+    
+    if /i NOT "%RECONFIGURE%"=="y" (
+        echo.
+        echo Configuration unchanged. Exiting.
+        pause
+        exit /b 0
+    )
+    
+    echo.
+    del "%USERPROFILE%\.lcs_config\config.json"
+    echo Old configuration deleted.
+    echo.
+)
+
+REM Run configuration
+python.exe "%~dp0..\cli_switcher.py" --channel 1
+
+echo.
+echo ======================================================================
+if %ERRORLEVEL% EQU 0 (
+    echo Configuration saved successfully!
+    echo.
+    echo You can now use the channel switcher shortcuts:
+    echo   - switch-channel-1.bat
+    echo   - switch-channel-2.bat
+    echo   - switch-channel-3.bat
+) else (
+    echo Configuration failed! 
+    echo Please check error messages above.
+)
+echo ======================================================================
+pause

--- a/tools/shortcuts/configure.sh
+++ b/tools/shortcuts/configure.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Logitech Channel Switcher - Configure Devices
+# Run this script to set up your keyboard and mouse assignment
+
+echo "======================================================================"
+echo " Logitech Channel Switcher - CONFIGURATION"
+echo "======================================================================"
+echo
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check if config already exists
+CONFIG_FILE="$HOME/.lcs_config/config.json"
+
+if [ -f "$CONFIG_FILE" ]; then
+    echo "Configuration already exists at:"
+    echo "$CONFIG_FILE"
+    echo
+    read -p "Do you want to reconfigure? (y/n): " RECONFIGURE
+    
+    if [[ ! "$RECONFIGURE" =~ ^[Yy]$ ]]; then
+        echo
+        echo "Configuration unchanged. Exiting."
+        exit 0
+    fi
+    
+    echo
+    rm "$CONFIG_FILE"
+    echo "Old configuration deleted."
+    echo
+fi
+
+# Run configuration (interactive mode)
+python3 "$SCRIPT_DIR/../cli_switcher.py" --channel 1
+
+echo
+echo "======================================================================"
+if [ $? -eq 0 ]; then
+    echo "Configuration saved successfully!"
+    echo
+    echo "You can now use the channel switcher shortcuts:"
+    echo "  - switch-channel-1.sh"
+    echo "  - switch-channel-2.sh"
+    echo "  - switch-channel-3.sh"
+else
+    echo "Configuration failed!"
+    echo "Please check error messages above."
+fi
+echo "======================================================================"

--- a/tools/shortcuts/switch-channel-1.bat
+++ b/tools/shortcuts/switch-channel-1.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Logitech Channel Switcher - Switch to Channel 1
+REM 
+REM FIRST-TIME USERS: This will auto-configure on first run!
+REM (Or run "configure.bat" for manual/interactive setup)
+REM 
+REM This script uses pythonw.exe to run silently without a console window.
+REM To create a keyboard shortcut: Right-click this file > Create Shortcut > 
+REM Right-click the shortcut > Properties > Shortcut key > Set your key combo
+
+pythonw.exe "%~dp0..\cli_switcher.py" --channel 1 --quiet

--- a/tools/shortcuts/switch-channel-1.sh
+++ b/tools/shortcuts/switch-channel-1.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Logitech Channel Switcher - Switch to Channel 1
+# This script runs the CLI switcher in quiet mode
+# 
+# To create a keyboard shortcut:
+# - GNOME: Settings > Keyboard > Custom Shortcuts
+# - KDE: System Settings > Shortcuts > Custom Shortcuts
+# - macOS: System Preferences > Keyboard > Shortcuts > App Shortcuts
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the CLI switcher
+python3 "$SCRIPT_DIR/../cli_switcher.py" --channel 1 --quiet

--- a/tools/shortcuts/switch-channel-2.bat
+++ b/tools/shortcuts/switch-channel-2.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Logitech Channel Switcher - Switch to Channel 2
+REM 
+REM FIRST-TIME USERS: This will auto-configure on first run!
+REM (Or run "configure.bat" for manual/interactive setup)
+REM 
+REM This script uses pythonw.exe to run silently without a console window.
+REM To create a keyboard shortcut: Right-click this file > Create Shortcut > 
+REM Right-click the shortcut > Properties > Shortcut key > Set your key combo
+
+pythonw.exe "%~dp0..\cli_switcher.py" --channel 2 --quiet

--- a/tools/shortcuts/switch-channel-2.sh
+++ b/tools/shortcuts/switch-channel-2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Logitech Channel Switcher - Switch to Channel 2
+# This script runs the CLI switcher in quiet mode
+# 
+# To create a keyboard shortcut:
+# - GNOME: Settings > Keyboard > Custom Shortcuts
+# - KDE: System Settings > Shortcuts > Custom Shortcuts
+# - macOS: System Preferences > Keyboard > Shortcuts > App Shortcuts
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the CLI switcher
+python3 "$SCRIPT_DIR/../cli_switcher.py" --channel 2 --quiet

--- a/tools/shortcuts/switch-channel-3.bat
+++ b/tools/shortcuts/switch-channel-3.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Logitech Channel Switcher - Switch to Channel 3
+REM 
+REM FIRST-TIME USERS: This will auto-configure on first run!
+REM (Or run "configure.bat" for manual/interactive setup)
+REM 
+REM This script uses pythonw.exe to run silently without a console window.
+REM To create a keyboard shortcut: Right-click this file > Create Shortcut > 
+REM Right-click the shortcut > Properties > Shortcut key > Set your key combo
+
+pythonw.exe "%~dp0..\cli_switcher.py" --channel 3 --quiet

--- a/tools/shortcuts/switch-channel-3.sh
+++ b/tools/shortcuts/switch-channel-3.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Logitech Channel Switcher - Switch to Channel 3
+# This script runs the CLI switcher in quiet mode
+# 
+# To create a keyboard shortcut:
+# - GNOME: Settings > Keyboard > Custom Shortcuts
+# - KDE: System Settings > Shortcuts > Custom Shortcuts
+# - macOS: System Preferences > Keyboard > Shortcuts > App Shortcuts
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the CLI switcher
+python3 "$SCRIPT_DIR/../cli_switcher.py" --channel 3 --quiet


### PR DESCRIPTION
Adds `tools/cli_switcher.py` to allow direct channel switching via OS shortcuts without background daemons.

- Implements zero-touch provisioning (auto-runs probe if settings are missing).
- Adds `--quiet` mode for silent execution.
- Includes ready-to-use shortcut scripts for Windows/Linux/macOS and comprehensive documentation.